### PR TITLE
rebase to debian trixie use appimage

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -29,8 +29,8 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`mediaelch_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -sX GET http://ppa.launchpad.net/mediaelch/mediaelch-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: mediaelch' | awk -F ': ' '/Version/{print $2;exit}')
-          echo "Type is \`custom_version_command\`" >> $GITHUB_STEP_SUMMARY
+          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/Komet/MediaElch/releases/latest" | jq -r '. | .tag_name')
+          echo "Type is \`github_stable\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^mediaelch_master_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
             echo "> Github organizational variable \`SKIP_EXTERNAL_TRIGGER\` matches current external release; skipping trigger." >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
+FROM ghcr.io/linuxserver/baseimage-selkies:debiantrixie
 
 # set version label
 ARG BUILD_DATE
@@ -11,7 +11,6 @@ LABEL maintainer="thelamer"
 
 # title
 ENV TITLE=Mediaelch \
-    NO_GAMEPAD=true \
     PIXELFLUX_WAYLAND=true
 
 RUN \
@@ -20,14 +19,26 @@ RUN \
     /usr/share/selkies/www/icon.png \
     https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/mediaelch-logo.png && \
   echo "**** install packages ****" && \
-  add-apt-repository ppa:mediaelch/mediaelch-stable && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     libqt6multimedia6 \
     libqt6sql6-sqlite \
     libqt6svg6 \
-    "mediaelch${MEDIAELCH_VERSION:+=$MEDIAELCH_VERSION}" \
     qt6-image-formats-plugins && \
+  echo "**** install mediaelch ****" && \
+  mkdir -p /opt/mediaelch && \
+  DOWNLOAD_URL=$(curl -sX GET "https://api.github.com/repos/Komet/MediaElch/releases/latest" \
+    | awk -F '(": "|")' '/https.*MediaElch_linux.*AppImage/ {print $3}') && \
+  curl -o \
+    /tmp/mediaelch.app -L \
+    "${DOWNLOAD_URL}" && \
+  chmod +x /tmp/mediaelch.app && \
+  cd /tmp && \
+  ./mediaelch.app --appimage-extract && \
+  mv squashfs-root/* /opt/mediaelch && \
+  cp \
+    /opt/mediaelch/usr/share/pixmaps/MediaElch.png \
+    /usr/share/pixmaps/MediaElch.png && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \
   apt-get autoclean && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,8 @@ pipeline {
     DOCKERHUB_TOKEN=credentials('docker-hub-ci-pat')
     QUAYIO_API_TOKEN=credentials('quayio-repo-api-token')
     GIT_SIGNING_KEY=credentials('484fbca6-9a4f-455e-b9e3-97ac98785f5f')
+    EXT_USER = 'Komet'
+    EXT_REPO = 'MediaElch'
     BUILD_VERSION_ARG = 'MEDIAELCH_VERSION'
     LS_USER = 'linuxserver'
     LS_REPO = 'docker-mediaelch'
@@ -144,16 +146,23 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is a custom command to determine version use that command
-    stage("Set tag custom bash"){
-      steps{
-        script{
-          env.EXT_RELEASE = sh(
-            script: ''' curl -sX GET http://ppa.launchpad.net/mediaelch/mediaelch-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: mediaelch' | awk -F ': ' '/Version/{print $2;exit}' ''',
-            returnStdout: true).trim()
-            env.RELEASE_LINK = 'custom_command'
-        }
-      }
+    // If this is a stable github release use the latest endpoint from github to determine the ext tag
+    stage("Set ENV github_stable"){
+     steps{
+       script{
+         env.EXT_RELEASE = sh(
+           script: '''curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq -r '. | .tag_name' ''',
+           returnStdout: true).trim()
+       }
+     }
+    }
+    // If this is a stable or devel github release generate the link for the build message
+    stage("Set ENV github_link"){
+     steps{
+       script{
+         env.RELEASE_LINK = 'https://github.com/' + env.EXT_USER + '/' + env.EXT_REPO + '/releases/tag/' + env.EXT_RELEASE
+       }
+     }
     }
     // Sanitize the release tag and strip illegal docker or github characters
     stage("Sanitize tag"){
@@ -1033,7 +1042,7 @@ pipeline {
                   "type": "commit",\
                   "tagger": {"name": "LinuxServer-CI","email": "ci@linuxserver.io","date": "'${GITHUB_DATE}'"}}'
               echo "Pushing New release for Tag"
-              echo "Updating to ${EXT_RELEASE_CLEAN}" > releasebody.json
+              curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq -r '. |.body' > releasebody.json
               jq -n \
                 --arg tag_name "$META_TAG" \
                 --arg target_commitish "master" \

--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **19.04.26:** - Rebase to Debian Trixie, ingest appimage from github.
 * **03.04.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **28.12.25:** - Add Wayland init logic.
 * **14.08.25:** - Rebase to noble, ingest latest stable version, install qt deps.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,13 +2,14 @@
 
 # jenkins variables
 project_name: docker-mediaelch
-external_type: na
-custom_version_command: "curl -sX GET http://ppa.launchpad.net/mediaelch/mediaelch-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: mediaelch' | awk -F ': ' '/Version/{print $2;exit}'"
+external_type: github_stable
 release_type: stable
 release_tag: latest
 ls_branch: master
 build_armhf: false
 repo_vars:
+  - EXT_USER = 'Komet'
+  - EXT_REPO = 'MediaElch'
   - BUILD_VERSION_ARG = 'MEDIAELCH_VERSION'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-mediaelch'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -104,6 +104,7 @@ init_diagram: |
   "mediaelch:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "19.04.26:", desc: "Rebase to Debian Trixie, ingest appimage from github."}
   - {date: "03.04.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "14.08.25:", desc: "Rebase to noble, ingest latest stable version, install qt deps."}

--- a/root/usr/bin/MediaElch
+++ b/root/usr/bin/MediaElch
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+cd /opt/mediaelch
+./AppRun


### PR DESCRIPTION
Looks like their PPA is not going to get updated for resolute, rebasing to trixie and using appimage release. 

The wrappers are for upgrade support. 